### PR TITLE
Laravel 8 support + recent Blueprint refactorings implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Quality Score](https://img.shields.io/scrutinizer/g/axitbv/laravel-blueprint-streamlined-test-addon.svg?style=flat-square)](https://scrutinizer-ci.com/g/axitbv/laravel-blueprint-streamlined-test-addon)
 [![Total Downloads](https://img.shields.io/packagist/dt/axitbv/laravel-blueprint-streamlined-test-addon.svg?style=flat-square)](https://packagist.org/packages/axitbv/laravel-blueprint-streamlined-test-addon)
 
-Swaps Blueprint's TestGenerator with my own [*too fancy* and *too specific*, *streamlined* tests](https://github.com/laravel-shift/blueprint/pull/220) for API Resource Controllers.
+Swaps Blueprint's TestGenerator with my own [streamlined tests](https://github.com/laravel-shift/blueprint/pull/220) for API Resource Controllers.
 
 ## Installation
 
@@ -69,7 +69,7 @@ Which will yield:
 
 Then, either run `php artisan test`:
 ```shell script
-❯ php artisan test                                                            
+❯ php artisan test
 
    PASS  Tests\Unit\ExampleTest
   ✓ basic test

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     ],
     "require": {
         "php": "^7.3",
-        "illuminate/support": "^7.0",
+        "illuminate/support": "^7.0|^8.0",
         "jasonmccreary/laravel-test-assertions": "^1.0"
     },
     "require-dev": {
         "laravel-shift/blueprint": "^1.14",
-        "orchestra/testbench": "^4.0|^5.0",
+        "orchestra/testbench": "^4.0|^5.0|^6.0",
         "phpunit/phpunit": "^8.0|^9.0"
     },
     "autoload": {

--- a/config/config.php
+++ b/config/config.php
@@ -4,5 +4,5 @@
  * You can place your custom package configuration in here.
  */
 return [
-
+    'generate_fqcn_route' => true,
 ];

--- a/src/BlueprintStreamlinedTestAddonServiceProvider.php
+++ b/src/BlueprintStreamlinedTestAddonServiceProvider.php
@@ -12,6 +12,11 @@ class BlueprintStreamlinedTestAddonServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->mergeConfigFrom(
+            __DIR__.'/../config/config.php',
+            'blueprint'
+        );
+
         $this->app->extend(Blueprint::class, function (Blueprint $blueprint, $app) {
             $blueprint->swapGenerator(
                 \Blueprint\Generators\TestGenerator::class,
@@ -20,4 +25,5 @@ class BlueprintStreamlinedTestAddonServiceProvider extends ServiceProvider
 
             return $blueprint;
         });
-    }}
+    }
+}

--- a/src/StreamlinedTestGenerator.php
+++ b/src/StreamlinedTestGenerator.php
@@ -456,7 +456,7 @@ class StreamlinedTestGenerator implements Generator
     private function testCaseStub()
     {
         if (empty($this->stubs['test-case'])) {
-            $this->stubs['test-case'] = $this->files->get(STUBS_PATH.'/test/case.stub');
+            $this->stubs['test-case'] = $this->files->get(STUBS_PATH.'/test.case.stub');
         }
 
         return $this->stubs['test-case'];

--- a/src/StreamlinedTestGenerator.php
+++ b/src/StreamlinedTestGenerator.php
@@ -115,7 +115,11 @@ class StreamlinedTestGenerator implements Generator
             $variable = Str::camel($context);
 
             if (in_array($name, ['edit', 'update', 'show', 'destroy'])) {
-                $setup['data'][] = sprintf('$%s = factory(%s::class)->create();', $variable, $model);
+                if (Blueprint::isLaravel8OrHigher()) {
+                    $setup['data'][] = sprintf('$%s = %s::factory()->create();', $variable, $model);
+                } else {
+                    $setup['data'][] = sprintf('$%s = factory(%s::class)->create();', $variable, $model);
+                }
             }
 
             foreach ($statements as $statement) {

--- a/src/StreamlinedTestGenerator.php
+++ b/src/StreamlinedTestGenerator.php
@@ -44,7 +44,7 @@ class StreamlinedTestGenerator implements Generator
     {
         $output = [];
 
-        $stub = $this->files->get(STUBS_PATH.'/test/class.stub');
+        $stub = $this->files->get(STUBS_PATH.'/test.class.stub');
 
         $this->registerModels($tree);
 
@@ -80,11 +80,11 @@ class StreamlinedTestGenerator implements Generator
         string $stub,
         Controller $controller
     ) {
-        $stub = str_replace('DummyNamespace', 'Tests\\Feature\\'.Blueprint::relativeNamespace($controller->fullyQualifiedNamespace()), $stub);
-        $stub = str_replace('DummyController', '\\'.$controller->fullyQualifiedClassName(), $stub);
-        $stub = str_replace('DummyClass', $controller->className().'Test', $stub);
-        $stub = str_replace('// test cases...', $this->buildTestCases($controller), $stub);
-        $stub = str_replace('// imports...', $this->buildImports($controller), $stub);
+        $stub = str_replace('{{ namespace }}', 'Tests\\Feature\\'.Blueprint::relativeNamespace($controller->fullyQualifiedNamespace()), $stub);
+        $stub = str_replace('{{ namespacedClass }}', '\\'.$controller->fullyQualifiedClassName(), $stub);
+        $stub = str_replace('{{ class }}', $controller->className().'Test', $stub);
+        $stub = str_replace('{{ body }}', $this->buildTestCases($controller), $stub);
+        $stub = str_replace('{{ imports }}', $this->buildImports($controller), $stub);
 
         return $stub;
     }

--- a/src/StreamlinedTestGenerator.php
+++ b/src/StreamlinedTestGenerator.php
@@ -619,11 +619,6 @@ END;
         }
     }
 
-    private function registerModels(array $tree)
-    {
-        $this->models = array_merge($tree['cache'] ?? [], $tree['models'] ?? []);
-    }
-
     private function splitField($field)
     {
         if (Str::contains($field, '.')) {

--- a/src/StreamlinedTestGenerator.php
+++ b/src/StreamlinedTestGenerator.php
@@ -396,8 +396,6 @@ class StreamlinedTestGenerator implements Generator
                 } elseif ($statement instanceof QueryStatement) {
                     $this->addRefreshDatabaseTrait($controller);
 
-                    $setup['data'][] =
-
                     if (Blueprint::isLaravel8OrHigher()) {
                         $setup['data'][] = sprintf('$%s = %s::factory()->times(3)->create();', Str::plural($variable), $model);
                     } else {

--- a/src/StreamlinedTestGenerator.php
+++ b/src/StreamlinedTestGenerator.php
@@ -114,6 +114,10 @@ class StreamlinedTestGenerator implements Generator
             $context = Str::singular($controller->prefix());
             $variable = Str::camel($context);
 
+            $modelNamespace = config('blueprint.models_namespace')
+                ? config('blueprint.namespace').'\\'.config('blueprint.models_namespace')
+                : config('blueprint.namespace');
+
             if (in_array($name, ['edit', 'update', 'show', 'destroy'])) {
                 if (Blueprint::isLaravel8OrHigher()) {
                     $setup['data'][] = sprintf('$%s = %s::factory()->create();', $variable, $model);

--- a/src/StreamlinedTestGenerator.php
+++ b/src/StreamlinedTestGenerator.php
@@ -15,6 +15,7 @@ use Blueprint\Models\Statements\RespondStatement;
 use Blueprint\Models\Statements\SendStatement;
 use Blueprint\Models\Statements\SessionStatement;
 use Blueprint\Models\Statements\ValidateStatement;
+use Blueprint\Tree;
 use Illuminate\Support\Str;
 
 class StreamlinedTestGenerator implements Generator
@@ -39,7 +40,7 @@ class StreamlinedTestGenerator implements Generator
         $this->files = $files;
     }
 
-    public function output(array $tree): array
+    public function output(Tree $tree): array
     {
         $output = [];
 
@@ -51,7 +52,7 @@ class StreamlinedTestGenerator implements Generator
         foreach ($tree['controllers'] as $controller) {
             $path = $this->getPath($controller);
 
-            if (!$this->files->exists(dirname($path))) {
+            if (! $this->files->exists(dirname($path))) {
                 $this->files->makeDirectory(dirname($path), 0755, true);
             }
 
@@ -176,7 +177,7 @@ class StreamlinedTestGenerator implements Generator
 
                             /** @var \Blueprint\Models\Model $model */
                             $local_model = $this->modelForContext($qualifier);
-                            if (!is_null($local_model) && $local_model->hasColumn($column)) {
+                            if (! is_null($local_model) && $local_model->hasColumn($column)) {
                                 $faker = FactoryGenerator::fakerData($local_model->column($column)->name()) ?? FactoryGenerator::fakerDataType($local_model->column($column)->dataType());
                             } else {
                                 $faker = 'word';
@@ -287,7 +288,6 @@ class StreamlinedTestGenerator implements Generator
                         $view_assertions[] = sprintf('$response->assertViewHas(\'%s\');', $data);
                     }
 
-
                     array_unshift($assertions['response'], ...$view_assertions);
                 } elseif ($statement instanceof RedirectStatement) {
                     $tested_bits |= self::TESTS_REDIRECT;
@@ -335,7 +335,7 @@ class StreamlinedTestGenerator implements Generator
                     if ($statement->operation() === 'save') {
                         $tested_bits |= self::TESTS_SAVE;
 
-                        if ($request_data && !$controller->isApiResource()) {
+                        if ($request_data && ! $controller->isApiResource()) {
                             $indent = str_pad(' ', 12);
                             $plural = Str::plural($variable);
                             $assertion = sprintf('$%s = %s::query()', $plural, $model);
@@ -382,7 +382,7 @@ class StreamlinedTestGenerator implements Generator
             }
             $call .= ')';
 
-            if ($request_data && !$controller->isApiResource()) {
+            if ($request_data && ! $controller->isApiResource()) {
                 $call .= ', [';
                 $call .= PHP_EOL;
                 foreach ($request_data as $key => $datum) {
@@ -608,8 +608,7 @@ END;
             return $this->models[Str::studly($context)];
         }
 
-        $matches = array_filter(array_keys($this->models), function ($key) use
-        (
+        $matches = array_filter(array_keys($this->models), function ($key) use (
             $context
         ) {
             return Str::endsWith($key, '/'.Str::studly($context));
@@ -618,8 +617,6 @@ END;
         if (count($matches) === 1) {
             return $this->models[$matches[0]];
         }
-
-        return null;
     }
 
     private function registerModels(array $tree)

--- a/src/StreamlinedTestGenerator.php
+++ b/src/StreamlinedTestGenerator.php
@@ -425,8 +425,8 @@ class StreamlinedTestGenerator implements Generator
             $body .= PHP_EOL.PHP_EOL;
             $body .= implode(PHP_EOL.PHP_EOL, array_map([$this, 'buildLines'], array_filter($assertions)));
 
-            $test_case = str_replace('dummy_test_case', $this->buildTestCaseName($name, $tested_bits), $test_case);
-            $test_case = str_replace('// ...', trim($body), $test_case);
+            $test_case = str_replace('{{ method }}', $this->buildTestCaseName($name, $tested_bits), $test_case);
+            $test_case = str_replace('{{ body }}', trim($body), $test_case);
 
             $test_cases .= PHP_EOL.$test_case.PHP_EOL;
         }


### PR DESCRIPTION
Fixes #1 

This PR will add support for Laravel 8 and will also incorporate recent refactors to Blueprint itself (most notably: the Tree class, the changes made to the stubs and compatibility for both Laravel 8 Model Factory classes as well as the legacy factory() method for older supported framework version).

During the implementation, I came across an issue with the registered API routes. The way that Blueprint registers these routes will cause exceptions in Laravel 8. I have raised an issue about this, which can be found here:

https://github.com/laravel-shift/blueprint/issues/377
